### PR TITLE
Update max memory allowed for lambda function

### DIFF
--- a/cloudformation/sam-template.yaml
+++ b/cloudformation/sam-template.yaml
@@ -37,7 +37,7 @@ Parameters:
     Default: 900
     Type: Number
   LambdaMemory:
-    Description: 'Optional: Lambda memory in MB (min 128 - 3008 max).'
+    Description: 'Optional: Lambda memory in MB (min 128 - 10,240 max).'
     Default: 3008
     Type: Number
   SparkLambdapermissionPolicyArn:


### PR DESCRIPTION
As, Lambda function now supports max memory up to 10250 MB.
There was a typo in CloudFormation template for Lambda memory limit specified as max limit of 3008 MB.