### PR TITLE
Adding 'unzip' package on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN yum update -y && \
     yum -y install yum-plugin-versionlock && \
     yum -y versionlock add java-1.8.0-openjdk-1.8.0.362.b08-0.amzn2.0.1.x86_64 && \
     yum -y install java-1.8.0-openjdk && \
-
+    yum -y install unzip && \
+    
     pip install --upgrade pip && \
     pip install pyspark==$PYSPARK_VERSION boto3 && \
 


### PR DESCRIPTION
When we try to build the image using the "REDSHIFT" framework, it is necessary to use the "unzip" package for the Redshift JDBC driver. However, the package is not installed at any point. Therefore, I added the command "yum -y install unzip" in the Dockerfile during the installation/update of system dependencies.